### PR TITLE
Ulaa v2.30.0 and chromium v135.0.7049.53

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,14 @@
     </screenshot>
   </screenshots>
     <releases>
+    <release version="2.30.0" date="2025-04-02">
+      <description>
+        <ul>
+          <li>Updated to Chromium Version 135.0.7049.53 with the latest security patches and performance improvements.</li>
+          <li>[Desktop][BugFix] Resolved high CPU usage issue.</li>
+        </ul>
+      </description>
+    </release>
       <release version="2.29.4" date="2025-03-26">
       <description>
         <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -100,9 +100,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.29.4-amd64.deb
-        sha256: 8ef38edf5361603f44142f176a969d94a8fcd3b7a7623f3f4bc05af43082df77
-        size: 141188636
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.30.0-amd64.deb
+        sha256: 5e148c49fbbf4b24a4a0fabace2220a247ec4309ad3812b26abc7cbf8d152797
+        size: 141526588
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated to Chromium Version 135.0.7049.53 with the latest security patches and performance improvements