### PR TITLE
Ulaa v2.30.2 and Chromium v135.0.7049.100 for linux

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,13 @@
     </screenshot>
   </screenshots>
     <releases>
+    <release version="2.30.2" date="2025-04-16">
+      <description>
+        <ul>
+          <li>Updated to Chromium Version 135.0.7049.100 with the latest security patches and performance improvements.</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.30.1" date="2025-04-09">
       <description>
         <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -100,9 +100,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.30.1-amd64.deb
-        sha256: 3fc7951fedeae27d4818490b984e13af3957481878cf759535fdfb9cb3f12ccb
-        size: 141620092
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.30.2-amd64.deb
+        sha256: c30436ed851e5dccda442aada8e4689ffdea6fcee5ac88ad4bc65f0d3ea5e7ed
+        size: 141674964
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated to Chromium Version 135.0.7049.100 with the latest security patches and performance improvements.