### PR TITLE
Ulaa v2.30.3 and Chromium v135.0.7049.114 for Linux

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,16 @@
     </screenshot>
   </screenshots>
     <releases>
+    <release version="2.30.3" date="2025-04-23">
+      <description>
+        <ul>
+          <li>Updated to Chromium Version 135.0.7049.114 with the latest security patches and performance improvements.</li>
+          <li>[Desktop][UI] Implemented a "Skip" button in the Welcome Tour for new users, with the option to revisit it via the "ulaa://welcome" URL.</li>
+          <li>[Desktop][Experimental][Enterprise] Added extension installation events to enterprise logs.</li>
+          <li>[Desktop][BugFix] Fixed a crash occurring when launching pop-ups.</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.30.2" date="2025-04-16">
       <description>
         <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -100,9 +100,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.30.2-amd64.deb
-        sha256: c30436ed851e5dccda442aada8e4689ffdea6fcee5ac88ad4bc65f0d3ea5e7ed
-        size: 141674964
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.30.3-amd64.deb
+        sha256: 07fc1e2a8dfb71e86b869bbdf711efc1923ca0db1784c02d7dc8c815652dba33
+        size: 141600784
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
* Updated to Chromium Version 135.0.7049.114 with the latest security patches and performance improvements.
* [Desktop][UI] Implemented a "Skip" button in the Welcome Tour for new users, with the option to revisit it via the "ulaa://welcome" URL.
* [Desktop][Experimental][Enterprise] Added extension installation events to enterprise logs.
* [Desktop][BugFix] Fixed a crash occurring when launching pop-ups.