### PR TITLE
Ulaa v2.31.2 and Chromium v136.0.7103.94

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,19 @@
     </screenshot>
   </screenshots>
     <releases>
+    <release version="2.31.2" date="2025-05-09">
+        <description>
+          <ul>
+            <li>Updated to Chromium Version 136.0.7103.94.</li>
+            <li>[Desktop] Added policy to restrict file downloads in managed browsers.</li>
+            <li>[Desktop] Added policy to restrict printing in managed browsers.</li>
+            <li>[Desktop] Added policy to apply watermark while printing documents in managed browsers.</li>
+            <li>[Desktop][Experimental] Initial integration of Ulaa AI Assistant with a toolbar button for quick access.</li>
+            <li>[Desktop][BugFix] Updated the "Learn more" URL on the 'HTTPS-only mode' blocking page to redirect users to the Advanced security settings support document.
+</li>
+          </ul>
+        </description>
+      </release>
     <release version="2.31.1" date="2025-05-07">
         <description>
           <ul>

--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -66,8 +66,7 @@
             <li>[Desktop] Added policy to restrict printing in managed browsers.</li>
             <li>[Desktop] Added policy to apply watermark while printing documents in managed browsers.</li>
             <li>[Desktop][Experimental] Initial integration of Ulaa AI Assistant with a toolbar button for quick access.</li>
-            <li>[Desktop][BugFix] Updated the "Learn more" URL on the 'HTTPS-only mode' blocking page to redirect users to the Advanced security settings support document.
-</li>
+            <li>[Desktop][BugFix] Updated the "Learn more" URL on the 'HTTPS-only mode' blocking page to redirect users to the Advanced security settings support document.</li>
           </ul>
         </description>
       </release>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -100,9 +100,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.31.1-amd64.deb
-        sha256: f40f339e4a380c4dc2bd69ce176fe229e0aa9a67023fba9ca4159a14e6328b0f
-        size: 142792280
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.31.2-amd64.deb
+        sha256: 8aad2c73bede20e5d7cba3b826de0dcb9ea635b0079318cd7668b1fa8f0cbb85
+        size: 142802472
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated to Chromium Version 136.0.7103.94.
[Desktop] Added policy to restrict file downloads in managed browsers.
[Desktop] Added policy to restrict printing in managed browsers.
[Desktop] Added policy to apply watermark while printing documents in managed browsers.
[Desktop][Experimental] Initial integration of Ulaa AI Assistant with a toolbar button for quick access.
[Desktop][BugFix] Updated the "Learn more" URL on the 'HTTPS-only mode' blocking page to redirect users to the Advanced security settings support document.