### PR TITLE
Ulaa v2.32.1 & Chromium v137.0.7151.72 for linux

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,15 @@
     </screenshot>
   </screenshots>
     <releases>
+    <release version="2.32.1" date="2025-06-03">
+        <description>
+          <ul>
+            <li>Updated to Chromium Version 137.0.7151.72 with the latest security patches and performance improvements.</li>
+            <li>[Desktop][Enterprise] Show a dialog when attempting to take screenshots through extensions under ScreenCapture policies.</li>
+            <li>[Desktop][Enterprise][BugFix] Deprecated the Rawpolicy endpoint in the browser.</li>
+          </ul>
+        </description>
+      </release>
     <release version="2.32.0" date="2025-05-28">
         <description>
           <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -100,9 +100,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.32.0-amd64.deb
-        sha256: c9d9b0944722107255ab0ea3a6669237a51064c67d711da96a8e62641abe2fb5
-        size: 144344200
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.32.1-amd64.deb
+        sha256: 3f5d14b3567d406a6607ed9e30da0114a5a362aca2f1adc6f3edd881deb21fbc
+        size: 144409840
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated to Chromium Version 137.0.7151.72 with the latest security patches and performance improvements.
