### PR TITLE
Update to ulaa v2.33.4

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,19 @@
     </screenshot>
   </screenshots>
   <releases>
+      <release version="2.33.4" date="2025-07-23">
+      <description>
+        <ul>
+          <li>[Desktop][UI] Resolved high CPU usage issue on the Downloads page.</li>
+          <li>[Desktop][UI] Included more size options for page zoom under the Appearance section in Preferences.</li>
+          <li>[Desktop][Enterprise] Added Extension Telemetry logs to Ulaa Logger.</li>
+          <li>[Desktop][Enterprise] Added enrollment-related info in the Preferences page.</li>
+          <li>[Desktop][Bug Fix] Resolved empty policy check for the File Upload Restriction Policy.</li>
+          <li>[Desktop][Bug Fix] Fixed Auto Mode Switching issue when a tab is restored via "Continue where you left off".</li>
+          <li>Updated with the latest security patches and performance enhancements. Chromium engine updated to 138.0.7204.169.</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.33.3" date="2025-07-16">
       <description>
         <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -98,9 +98,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.33.3-amd64.deb
-        sha256: c627b195dfd7b9130706923a18e76c985b07d33243986a6edab7bd9e20260d17
-        size: 143145684
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.33.4-amd64.deb
+        sha256: 2c2f3860f4f4d04c4925aa178923237f8fb7c983ecb4b12319f9fbf2e6fa450f
+        size: 143108944
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated with the latest security patches and performance enhancements. Chromium engine updated to 138.0.7204.169.