### PR TITLE
Update to ulaa v2.34.1

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,13 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="2.34.1" date="2025-08-11">
+      <description>
+        <ul>
+          <li>Updated with the latest security patches and performance enhancements. Chromium engine updated to 139.0.7258.128.</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.34.0" date="2025-08-06">
       <description>
         <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -98,9 +98,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.34.0-amd64.deb
-        sha256: 0fc1aad88daa16d69563d665aa4b5d005056a48a08637e9a66a83abb45483a69
-        size: 143226300
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.34.1-amd64.deb
+        sha256: 232ce672866aa84ed22209c69f50caf148f0cc14fbdf8d038e75d104cc800831
+        size: 143255148
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated with the latest security patches and performance enhancements. Chromium engine updated to 139.0.7258.128.