### PR TITLE
[MinorBump] Update to Ulaa v2.34.2

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,17 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="2.34.2" date="2025-08-20">
+      <description>
+        <ul>
+          <li>[Desktop] Enhanced Safe Browsing for file downloads.</li>
+          <li>[Desktop][Experiment] Enabled the Enterprise Heartbeat feature flag by default.</li>
+          <li>[Desktop][Experimental] Introduced Productivity Suite feature in the sidebar.</li>
+          <li>[Desktop][BugFix] Resolved performance issues with Ulaa Adblocker.</li>
+          <li>Updated with the latest security patches and performance enhancements. Chromium engine updated to 139.0.7258.143.</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.34.1" date="2025-08-13">
       <description>
         <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -98,9 +98,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.34.1-amd64.deb
-        sha256: 232ce672866aa84ed22209c69f50caf148f0cc14fbdf8d038e75d104cc800831
-        size: 143255148
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.34.2-amd64.deb
+        sha256: f9c26d1da47ebbeaeee066ba0e91027655f08312c03cc0891a446b762e704146
+        size: 143612180
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated with the latest security patches and performance enhancements. Chromium engine updated to 139.0.7258.143.