### PR TITLE
Ulaa v2.35.3 & Chromium v140.0.7339.185 for linux

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,15 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="2.35.3" date="2025-09-18">
+      <description>
+        <ul>
+          <li>[Desktop][Enterprise] Revamped enterprise logs.</li>
+          <li>[Desktop][BugFix] Fixed an RCE vulnerability in Policy Injection by restricting the 'SetLocalTestPolicies' API.</li>
+          <li>Updated with the latest security patches and performance enhancements. Chromium engine updated to 140.0.7339.185.</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.35.2" date="2025-09-10">
       <description>
         <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -98,9 +98,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.35.2-amd64.deb
-        sha256: bedd76aefeae90ab75b6beef5405c117305a44f0fa5bd066d9a5b1c7c9a9c128
-        size: 144791268
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.35.3-amd64.deb
+        sha256: 7616d41982270ee67dca3f3c322e27d7eae1fa5b581ee59dddc909d3c5986a0d
+        size: 144803548
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated with the latest security patches and performance enhancements. Chromium engine updated to 140.0.7339.185.