### PR TITLE
Update to ulaa v2.36.0

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,14 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="2.36.0" date="2025-10-01">
+      <description>
+        <ul>
+          <li>[Desktop] Enhanced Safe Browsing file download handling with a user keep/discard option.</li>
+          <li>Updated with the latest security patches and performance enhancements. Chromium engine updated to 141.0.7390.54.</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.35.4" date="2025-09-24">
       <description>
         <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -98,9 +98,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.35.4-amd64.deb
-        sha256: 7e06d1024886a4f3f87601929459ac558b6a8f1e0824bc90a95f23efb853d241
-        size: 144221956
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.36.0-amd64.deb
+        sha256: 1cb083f2794642ee1f1052f84de24d35d0e4bc722e3f8ed0b7ff09848dd40424
+        size: 144339220
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated with the latest security patches and performance enhancements. Chromium engine updated to 141.0.7390.54.