### PR TITLE
Update to ulaa v2.36.4

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,13 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="2.36.4" date="2025-10-22">
+      <description>
+        <ul>
+          <li>Updated with the latest security patches and performance enhancements. Chromium engine updated to 141.0.7390.123.</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.36.3" date="2025-10-15">
       <description>
         <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -98,9 +98,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.36.3-amd64.deb
-        sha256: ec0e0f9f16ddcadc1e2efc62574e73c4b782ba329c28dc703957e35fe89c73bf
-        size: 141900504
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.36.4-amd64.deb
+        sha256: 0ba2f6f76e5a5b9a280143efb9d407b739eff301cf92db7afc66a6a8921b0486
+        size: 141851144
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated with the latest security patches and performance enhancements. Chromium engine updated to 141.0.7390.123.