### PR TITLE
Update to ulaa v2.37.2

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,13 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="2.37.2" date="2025-11-06">
+      <description>
+        <ul>
+          <li>Updated with the latest security patches and performance enhancements. Chromium engine updated to 142.0.7444.138.</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.37.0" date="2025-10-29">
       <description>
         <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -98,9 +98,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.37.0-amd64.deb
-        sha256: 5e4ca448bfb5588626e46bb0cffd05bed154420adc33321a9f1023102f0548ec
-        size: 139571544
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.37.2-amd64.deb
+        sha256: 8432a9ecaa7acf50b7578f5571e028dfad100048aa311d705dde51c97efa8730
+        size: 139591692
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated with the latest security patches and performance enhancements. Chromium engine updated to 142.0.7444.138.