### PR TITLE
Update to ulaa v2.37.3

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,16 @@
     </screenshot>
   </screenshots>
   <releases>
+  <release version="2.37.3" date="2025-11-12">
+      <description>
+        <ul>
+          <li>[Desktop][Enterprise] Added Ulaa device ID to the enrollment configuration.</li>
+          <li>[Desktop][Enterprise] Refined Enterprise Log data.</li>
+          <li>[Desktop][BugFix] Sent Enterprise Logs to enrollment-based region.</li>
+          <li>Updated with the latest security patches and performance enhancements. Chromium engine updated to 142.0.7444.163.</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.37.2" date="2025-11-06">
       <description>
         <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -98,9 +98,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.37.2-amd64.deb
-        sha256: 8432a9ecaa7acf50b7578f5571e028dfad100048aa311d705dde51c97efa8730
-        size: 139591692
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.37.3-amd64.deb
+        sha256: 944d9a5066023b8e6214e04bde71f52a50e0b42d3619e828b5d1d9a196021385
+        size: 139691748
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated with the latest security patches and performance enhancements. Chromium engine updated to 142.0.7444.163.