### PR TITLE
Update to ulaa v2.38.0

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,15 @@
     </screenshot>
   </screenshots>
   <releases>
+  <release version="2.38.0" date="2025-12-03">
+    <description>
+      <ul>
+        <li>[Desktop][UI][Preferences] Implemented "Manage Security Keys" in the Preferences page.</li>
+        <li>[Linux][BugFix] Corrected the update instructions for Flatpak installation.</li>
+        <li>Updated with the latest security patches and performance enhancements. Chromium engine updated to 143.0.7499.92.</li>
+      </ul>
+    </description>
+  </release>
   <release version="2.37.4" date="2025-11-18">
     <description>
       <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -98,9 +98,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.37.4-amd64.deb
-        sha256: c033e6f0923d53700d1d5547218fc47cce0fcef81670c7d081f276bcc48967ca
-        size: 139644516
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.38.0-amd64.deb
+        sha256: ae26afc0cb084489cc9d2f770eb98f5563e3fe4a46352e3f4c612eb1cc98110f
+        size: 139916640
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
* Updated with the latest security patches and performance enhancements. Chromium engine updated to 143.0.7499.92.