### PR TITLE
Update to ulaa v2.38.3

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,18 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="2.38.3" date="2025-12-17">
+      <description>
+        <ul>
+          <li>[Desktop][UI] Added an option to enable or disable the Ulaa Notes icon in the toolbar.</li>
+          <li>[Desktop][UI] Introduced a search option in the profiles list.</li>
+          <li>[Desktop][BugFix] Updated embedded redirection URLs to use the .in top-level domain instead of .com.​</li>
+          <li>[Desktop] Added a status indicator and a reason showing whether “Offer to Save Password” is enforced.</li>
+          <li>[Desktop] Extended native messaging extension support to include Ulaa and Chrome paths at both system and user levels.</li>
+          <li>Updated with the latest security patches and performance enhancements. Chromium engine updated to 143.0.7499.151.</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.38.2" date="2025-12-11">
       <description>
         <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -98,9 +98,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.38.2-amd64.deb
-        sha256: e3ccc90fd2eb40ae47cbda55794c37efcd58d6bde1e192871ca4e11f655a144c
-        size: 139945808
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.38.3-amd64.deb
+        sha256: 6bcdf2ceb6f72815c8a000a337cf23d7c08c5f80afde2db5c5cee33960b1ae7b
+        size: 139896840
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated with the latest security patches and performance enhancements. Chromium engine updated to 143.0.7499.151.