### PR TITLE
Update to ulaa v2.39.0

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,13 @@
     </screenshot>
   </screenshots>
   <releases>
+  <release version="2.39.0" date="2026-01-14">
+      <description>
+        <ul>
+          <li>Updated with the latest security patches and performance enhancements. Chromium engine updated to 144.0.7559.85.</li>
+        </ul>
+      </description>
+  </release>
   <release version="2.38.4" date="2026-01-07">
       <description>
         <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -98,9 +98,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.38.4-amd64.deb
-        sha256: 7897561d9963d6e57fe7b91f964543f96f5ff8bf7eea656914b03a3450c0bf19
-        size: 139937448
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.39.0-amd64.deb
+        sha256: 403da139552d5f617ae8ebe1036609635a1a47fe897d51138872ec638117d61f
+        size: 140486856
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated with the latest security patches and performance enhancements. Chromium engine updated to 144.0.7559.85.