### PR TITLE
Update to ulaa v2.39.2

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,14 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="2.39.2" date="2026-01-28">
+      <description>
+        <ul>
+          <li>[Desktop][BugFix] Added support for the --disable-features command-line flag.</li>
+          <li>Updated with the latest security patches and performance enhancements. Chromium engine updated to 144.0.7559.110.</li>
+        </ul>
+      </description>
+  </release>
     <release version="2.39.1" date="2026-01-21">
       <description>
         <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -98,9 +98,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.39.1-amd64.deb
-        sha256: 04db87fff77b9fc78891616626dd31a02c240d7863458139d9ad9417a48c531b
-        size: 140632060
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.39.2-amd64.deb
+        sha256: 0cf26726c10cd752f7206c505e471279d3be602dcb155c466fb5cd51ceac775f
+        size: 140573436
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated with the latest security patches and performance enhancements. Chromium engine updated to 144.0.7559.110.