### PR TITLE
Update to Ulaa v2.42.3

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,14 @@
     </screenshot>
   </screenshots>
   <releases>
+  <release version="2.42.3" date="2026-04-23">
+      <description>
+        <ul>
+          <li>[Desktop][Enterprise] Added enterprise logs for policy and download-related activities.</li>
+          <li>Updated with the latest security patches and performance enhancements. Chromium engine updated to 147.0.7727.117</li>
+        </ul>
+      </description>
+    </release>
   <release version="2.42.2" date="2026-04-16">
       <description>
         <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -98,9 +98,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.42.2-amd64.deb
-        sha256: 6bfdc7b45a2fcdc0dae85a8e402c94a20f365ed87183934225517b099ceb974e
-        size: 144351336
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.42.3-amd64.deb
+        sha256: edf1a1545561159435feb114c953d2b7395ff1301b26b910a32443c12cd1afef
+        size: 144417232
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated with the latest security patches and performance enhancements. Chromium engine updated to 147.0.7727.117.