### PR TITLE
Update to ulaa-v2.44.1

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,13 @@
     </screenshot>
   </screenshots>
   <releases>
+  <release version="2.44.1" date="2026-06-09">
+	  <description>
+		<ul>
+          <li>Updated with the latest security patches and performance enhancements. Chromium engine updated to 149.0.7827.103.</li>
+        </ul>
+	  </description>
+	</release>
   <release version="2.44.0" date="2026-06-04">
 	  <description>
 		<ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -98,9 +98,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.44.0-amd64.deb
-        sha256: 17ac566b7982f5542e667be142616a0bb077da675c3b164dc5b4bb473d1bc8b1
-        size: 149472312
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.44.1-amd64.deb
+        sha256: 0bea83dec7d45e9e1f211e9f17574e5a2e24d57e408b1ac97a5aac402ca6f088
+        size: 149518436
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated with the latest security patches and performance enhancements. Chromium engine updated to 149.0.7827.103.