### PR TITLE
Update the ulaa v2.44.5

### DIFF
--- a/com.ulaa.Ulaa.metainfo.xml
+++ b/com.ulaa.Ulaa.metainfo.xml
@@ -58,6 +58,13 @@
     </screenshot>
   </screenshots>
   <releases>
+  <release version="2.44.5" date="2026-06-24">
+	  <description>
+		  <ul>
+          <li>Updated with the latest security patches and performance enhancements. Chromium engine updated to 149.0.7827.197.</li>
+      </ul>
+	  </description>
+	</release>
   <release version="2.44.4" date="2026-06-17">
 	  <description>
 		  <ul>

--- a/com.ulaa.Ulaa.yml
+++ b/com.ulaa.Ulaa.yml
@@ -98,9 +98,9 @@ modules:
       - install -Dm 644 com.ulaa.Ulaa.svg /app/share/icons/hicolor/scalable/apps/com.ulaa.Ulaa.svg
     sources:
       - type: extra-data
-        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.44.4-amd64.deb
-        sha256: ed7e0fc5ec82198458bd6927411f5005b11b3b429d8bf5cc3ee75e062f909784
-        size: 149552420
+        url: https://ulaa.zoho.com/release/linux/stable/Ulaa-Browser-v2.44.5-amd64.deb
+        sha256: 8f7ac8961bac980e030da9f022e227676217f9d4441b80ab12eb2ee421dab3d9
+        size: 149401184
         filename: ulaa.deb
         x-checker-data:
           type: debian-repo


### PR DESCRIPTION
Updated with the latest security patches and performance enhancements. Chromium engine updated to 149.0.7827.197.